### PR TITLE
Add help pages submodule for "latest" and redirect

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "help/0.9.13"]
 	path = help/0.9.13
 	url = https://github.com/mu-editor/help-pages.git
+[submodule "help/latest"]
+	path = help/latest
+	url = https://github.com/mu-editor/help-pages.git

--- a/help/index.html
+++ b/help/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE HTML>
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <meta http-equiv="refresh" content="1; url=latest/">
+        <script type="text/javascript">
+            window.location.href = "latest/"
+        </script>
+        <title>Help redirect to latest version</title>
+    </head>
+    <body>
+        If you are not redirected automatically, please follow this link to the 
+        <a href='latest/'>latest version of the documentation</a>.
+    </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@ title: Code With Mu
   programmers. It's written in Python and works on Windows, OSX, Linux
   and Raspberry Pi.</p>
   <p><a class="btn btn-lg btn-success" href="#download"
-      role="button">Download now</a> <a class="btn btn-primary" role="button" href="/help/0.9.13">Help</a></p>
+      role="button">Download now</a> <a class="btn btn-primary" role="button" href="/help/">Help</a></p>
 </div>
 
 <div class="row marketing">


### PR DESCRIPTION
From the conversation in https://github.com/mu-editor/mu-editor.github.io/issues/15 it looks like this will be the simplest way to add a redirect to the http://codewith.mu/help URL.

I haven't been able to test this yet in my Jekyll (need to find it, don't really know where I might have left it!), but it's simple enough. @dannystaple could have a quick look whenever you could find some time?