### PR TITLE
Correct BeeWare links/naming

### DIFF
--- a/en/thanks.html
+++ b/en/thanks.html
@@ -354,13 +354,13 @@ only a minute of your time to tweet your appreciation.</p>
 </div>
 <div class="media">
   <div class="media-left">
-      <a href="https://pybee.org/">
+      <a href="https://beeware.org/">
         <img class="media-object img-rounded" src="/img/beeware.png" alt="BeeWare">
       </a>
   </div>
   <div class="media-body">
     <h4 class="media-heading">BeeWare</h4>
-    <p><a href="https://pybee.org/">BeeWare</a> is an amazing open source
+    <p><a href="https://beeware.org/">BeeWare</a> is an amazing open source
     project that makes it possible to create Python applications with rich
     graphical user interfaces that run on many different platforms (iOS,
     Android, Windows, MacOS, Linux, Web, and tvOS).</p>
@@ -368,11 +368,11 @@ only a minute of your time to tweet your appreciation.</p>
     <p>BeeWare is connected with Mu in a couple of ways. The visual debugger in
     Mu is inspired by and takes a similar approach to the BeeWare debugger
     called
-    <a href="https://pybee.org/project/projects/tools/bugjar/">BugJar</a>. When
+    <a href="https://beeware.org/project/projects/tools/bugjar/">BugJar</a>. When
     packaging Mu for Mac OSX we use BeeWare's amazing
-    <a href="https://pybee.org/project/projects/tools/briefcase/">Briefcase</a>
+    <a href="https://beewarbeeware/project/projects/tools/briefcase/">Briefcase</a>
     project. You cannot underestimate how hard it is to package Python
-    applications on Mac OSX, and without the initial help of PyBee's founder,
+    applications on Mac OSX, and without the initial help of BeeWare's founder,
     <a href="https://twitter.com/freakboy3742">Russell Keith-Magee</a> and
     subsequent use of Briefcase we'd still be scratching our heads and
     wondering how to make Mu easily installable on Mac OSX.</p>


### PR DESCRIPTION
BeeWare has recently consolidated on just BeeWare (not pybee) for it's organisation name and website; I've made some small edits to ensure this consistency on the mu thanks page. 🐝