### PR TITLE
Mu 1.0.3 requires PyQt 5.14 that requires macOS 10.13.

### DIFF
--- a/en/howto/1.0/install_macos.md
+++ b/en/howto/1.0/install_macos.md
@@ -8,7 +8,7 @@ i18n: en
 
 Installing Mu on macOS is super easy.
 
-Mu will run on any machine running macOS version 10.11 El Capitan or later. There is [advice on Apple's website](https://support.apple.com/en-us/HT201260) on how to check your macOS version.
+Mu will run on any machine running macOS version 10.13 High Sierra or later. There is [advice on Apple's website](https://support.apple.com/en-us/HT201260) on how to check your macOS version.
 
 The following (silent) video demonstrates this process on Mac OS Catalina:
 


### PR DESCRIPTION
@ntoll,

Sharing a minor fix, following the 1.0.3 release that, requiring PyQt 5.14, now implies macOS 10.13. See [this user's failure on the Mu issue tracker](https://github.com/mu-editor/mu/issues/997#issuecomment-582243822).

Once the alpha moves up to 5.14, the `1.1` document here will also need updating. :)

Thanks!