### PR TITLE
Fix links missing the doc version in the URL.

### DIFF
--- a/en/help/1.0.md
+++ b/en/help/1.0.md
@@ -55,4 +55,4 @@ title: Help for Mu 1.0.*
   </div>
 </div>
 
-**If you think you've found a bug in Mu, congratulations! Please [follow the steps outlined here](/en/howto/bugs).**
+**If you think you've found a bug in Mu, congratulations! Please [follow the steps outlined here](/en/howto/1.0/bugs).**

--- a/en/howto/1.1/copy_files_microbit.md
+++ b/en/howto/1.1/copy_files_microbit.md
@@ -20,7 +20,7 @@ The pane shown below will appear at the bottom of Mu's window. Simply click and
 drag a file between the list of files on the micro:bit and those on your
 computer (as the animation shows). The files on your computer can be found in
 the folder Mu uses as your working directory (see the tutorial called
-[where are my files?](/en/tutorials/1.0/files)).
+[where are my files?](/en/tutorials/1.1/files)).
 
 <div class="row">
   <img src="/img/en/howto/microbit_files.gif" alt="Moving files with a micro:bit" class="img-responsive center-block img-rounded movie"/>

--- a/en/tutorials/1.0/logs.md
+++ b/en/tutorials/1.0/logs.md
@@ -30,7 +30,7 @@ The first tab contains the logs written during the current day:
 </div>
 
 To learn what the log entries mean please read our guide for
-[how to read logs in Mu](/en/howto/read_logs).
+[how to read logs in Mu](/en/howto/1.0/read_logs).
 
 The second tab allows you to configure various aspects of the environment in
 which Python 3 runs your code (so called "environment variables"):
@@ -41,7 +41,7 @@ which Python 3 runs your code (so called "environment variables"):
 </div>
 
 To learn how to update the Python 3 environment with environment variables,
-read our guide for [how to do this](/en/howto/python3_envars).
+read our guide for [how to do this](/en/howto/1.0/python3_envars).
 
 Finally, the third tab contains various settings for flashing code onto a
 connected BBC micro:bit:
@@ -52,4 +52,4 @@ connected BBC micro:bit:
 </div>
 
 To learn how to change the way code is flashed onto a connected BBC micro:bit,
-read our guide for [how to do this](/en/howto/microbit_settings).
+read our guide for [how to do this](/en/howto/1.0/microbit_settings).

--- a/en/tutorials/1.0/problems.md
+++ b/en/tutorials/1.0/problems.md
@@ -11,7 +11,7 @@ As you'll know from writing your own code, all software has bugs!
 Mu is no exception and it's likely you may discover some odd behaviour or Mu
 may report a problem.
 
-If this is the case, we've [created a guide to help you submit a bug report](/en/howto/bugs).
+If this is the case, we've [created a guide to help you submit a bug report](/en/howto/1.0/bugs).
 We love getting feedback because bug reports help us to improve Mu and make it
 easy for our users to contribute back to the project.
 

--- a/en/tutorials/1.1/logs.md
+++ b/en/tutorials/1.1/logs.md
@@ -30,7 +30,7 @@ The first tab contains the logs written during the current day:
 </div>
 
 To learn what the log entries mean please read our guide for
-[how to read logs in Mu](/en/howto/read_logs).
+[how to read logs in Mu](/en/howto/1.1/read_logs).
 
 The second tab allows you to configure various aspects of the environment in
 which Python 3 runs your code (so called "environment variables"):
@@ -41,7 +41,7 @@ which Python 3 runs your code (so called "environment variables"):
 </div>
 
 To learn how to update the Python 3 environment with environment variables,
-read our guide for [how to do this](/en/howto/python3_envars).
+read our guide for [how to do this](/en/howto/1.1/python3_envars).
 
 Finally, the third tab contains various settings for flashing code onto a
 connected BBC micro:bit:
@@ -52,4 +52,4 @@ connected BBC micro:bit:
 </div>
 
 To learn how to change the way code is flashed onto a connected BBC micro:bit,
-read our guide for [how to do this](/en/howto/microbit_settings).
+read our guide for [how to do this](/en/howto/1.1/microbit_settings).

--- a/en/tutorials/1.1/problems.md
+++ b/en/tutorials/1.1/problems.md
@@ -11,7 +11,7 @@ As you'll know from writing your own code, all software has bugs!
 Mu is no exception and it's likely you may discover some odd behaviour or Mu
 may report a problem.
 
-If this is the case, we've [created a guide to help you submit a bug report](/en/howto/bugs).
+If this is the case, we've [created a guide to help you submit a bug report](/en/howto/1.1/bugs).
 We love getting feedback because bug reports help us to improve Mu and make it
 easy for our users to contribute back to the project.
 

--- a/es/help/1.0.md
+++ b/es/help/1.0.md
@@ -55,4 +55,4 @@ title: Help for Mu 1.0.*
   </div>
 </div>
 
-**If you think you've found a bug in Mu, congratulations! Please [follow the steps outlined here](/en/howto/bugs).**
+**If you think you've found a bug in Mu, congratulations! Please [follow the steps outlined here](/es/howto/1.0/bugs).**

--- a/es/help/1.1.md
+++ b/es/help/1.1.md
@@ -55,4 +55,4 @@ title: Help for Mu 1.1.*
   </div>
 </div>
 
-**If you think you've found a bug in Mu, congratulations! Please [follow the steps outlined here](/en/howto/bugs).**
+**If you think you've found a bug in Mu, congratulations! Please [follow the steps outlined here](/es/howto/1.1/bugs).**

--- a/es/howto/1.0/install_with_python.md
+++ b/es/howto/1.0/install_with_python.md
@@ -9,7 +9,7 @@ If you already have [Python3](https://python.org/) installed on your Windows,
 OSX or Linux machine then it is easy to install Mu with Python's
 built-in package manager, [`pip`](https://pip.pypa.io/en/stable/installing/).
 **Please note: this method does not currently work on Raspberry Pi** (use
-[these instructions instead](/en/howto/install_raspberry_pi)).
+[these instructions instead](/es/howto/1.0/install_raspberry_pi)).
 If you're on Windows and would rather not type commands you should use the
 [Windows installer for Mu](install_windows) instead. If you're using OSX on a
 Mac and want to use the simple drag-and-drop installer instead, you should use

--- a/es/howto/1.1/copy_files_microbit.md
+++ b/es/howto/1.1/copy_files_microbit.md
@@ -20,7 +20,7 @@ The pane shown below will appear at the bottom of Mu's window. Simply click and
 drag a file between the list of files on the micro:bit and those on your
 computer (as the animation shows). The files on your computer can be found in
 the folder Mu uses as your working directory (see the tutorial called
-[where are my files?](/en/tutorials/1.0/files)).
+[where are my files?](/en/tutorials/1.1/files)).
 
 <div class="row">
   <img src="/img/en/howto/microbit_files.gif" alt="Moving files with a micro:bit" class="img-responsive center-block img-rounded movie"/>

--- a/es/howto/1.1/install_with_python.md
+++ b/es/howto/1.1/install_with_python.md
@@ -9,7 +9,7 @@ If you already have [Python3](https://python.org/) installed on your Windows,
 OSX or Linux machine then it is easy to install Mu with Python's
 built-in package manager, [`pip`](https://pip.pypa.io/en/stable/installing/).
 **Please note: this method does not currently work on Raspberry Pi** (use
-[these instructions instead](/en/howto/install_raspberry_pi)).
+[these instructions instead](/es/howto/1.1/install_raspberry_pi)).
 If you're on Windows and would rather not type commands you should use the
 [Windows installer for Mu](install_windows) instead. If you're using OSX on a
 Mac and want to use the simple drag-and-drop installer instead, you should use

--- a/es/tutorials/1.0/logs.md
+++ b/es/tutorials/1.0/logs.md
@@ -30,7 +30,7 @@ The first tab contains the logs written during the current day:
 </div>
 
 To learn what the log entries mean please read our guide for
-[how to read logs in Mu](/en/howto/read_logs).
+[how to read logs in Mu](/es/howto/1.0/read_logs).
 
 The second tab allows you to configure various aspects of the environment in
 which Python 3 runs your code (so called "environment variables"):
@@ -41,7 +41,7 @@ which Python 3 runs your code (so called "environment variables"):
 </div>
 
 To learn how to update the Python 3 environment with environment variables,
-read our guide for [how to do this](/en/howto/python3_envars).
+read our guide for [how to do this](/es/howto/1.0/python3_envars).
 
 Finally, the third tab contains various settings for flashing code onto a
 connected BBC micro:bit:
@@ -52,4 +52,4 @@ connected BBC micro:bit:
 </div>
 
 To learn how to change the way code is flashed onto a connected BBC micro:bit,
-read our guide for [how to do this](/en/howto/microbit_settings).
+read our guide for [how to do this](/es/howto/1.0/microbit_settings).

--- a/es/tutorials/1.0/problems.md
+++ b/es/tutorials/1.0/problems.md
@@ -11,7 +11,7 @@ As you'll know from writing your own code, all software has bugs!
 Mu is no exception and it's likely you may discover some odd behaviour or Mu
 may report a problem.
 
-If this is the case, we've [created a guide to help you submit a bug report](/en/howto/bugs).
+If this is the case, we've [created a guide to help you submit a bug report](/es/howto/1.0/bugs).
 We love getting feedback because bug reports help us to improve Mu and make it
 easy for our users to contribute back to the project.
 

--- a/es/tutorials/1.1/logs.md
+++ b/es/tutorials/1.1/logs.md
@@ -30,7 +30,7 @@ The first tab contains the logs written during the current day:
 </div>
 
 To learn what the log entries mean please read our guide for
-[how to read logs in Mu](/en/howto/read_logs).
+[how to read logs in Mu](/es/howto/1.1/read_logs).
 
 The second tab allows you to configure various aspects of the environment in
 which Python 3 runs your code (so called "environment variables"):
@@ -41,7 +41,7 @@ which Python 3 runs your code (so called "environment variables"):
 </div>
 
 To learn how to update the Python 3 environment with environment variables,
-read our guide for [how to do this](/en/howto/python3_envars).
+read our guide for [how to do this](/es/howto/1.1/python3_envars).
 
 Finally, the third tab contains various settings for flashing code onto a
 connected BBC micro:bit:
@@ -52,4 +52,4 @@ connected BBC micro:bit:
 </div>
 
 To learn how to change the way code is flashed onto a connected BBC micro:bit,
-read our guide for [how to do this](/en/howto/microbit_settings).
+read our guide for [how to do this](/es/howto/1.1/microbit_settings).

--- a/es/tutorials/1.1/problems.md
+++ b/es/tutorials/1.1/problems.md
@@ -11,7 +11,7 @@ As you'll know from writing your own code, all software has bugs!
 Mu is no exception and it's likely you may discover some odd behaviour or Mu
 may report a problem.
 
-If this is the case, we've [created a guide to help you submit a bug report](/en/howto/bugs).
+If this is the case, we've [created a guide to help you submit a bug report](/es/howto/1.1/bugs).
 We love getting feedback because bug reports help us to improve Mu and make it
 easy for our users to contribute back to the project.
 


### PR DESCRIPTION
Found a broken link in the website and notice the same issue was present in a few different files, so this PR fixes the similar issues I found.

Also some of the Spanish pages were linking to the English version instead of the Spanish, so i've updated that as well (although to be fair those files were still in English anyway).