### PR TITLE
Fix Issue 1340 - Add language to uninstall Windows

### DIFF
--- a/en/howto/1.1/install_windows.md
+++ b/en/howto/1.1/install_windows.md
@@ -12,8 +12,9 @@ Mu works on 64 bit versions of Windows. It's a good idea to make sure your syste
 
 If you are in an educational setting you may need to get your system administrator to run the installer for you.
 
-**If you have an older version of Mu already installed, we recommend that you
-uninstall it first.**
+**If you have a version of Mu older than version 1.1 already installed, we recommend that you
+uninstall it first.  If you do not uninstall first, you will have two installations of Mu due to 
+packaging changes with Mu versions 1.1 and newer.**
 
 ## Step 1 - Download Mu Installer
 

--- a/en/tutorials/1.1/esp.md
+++ b/en/tutorials/1.1/esp.md
@@ -31,10 +31,10 @@ buttons:
   <br/>
 </div>
 
-The "Serial" button opens a serial data connection to the ESP board you
+The "Serial" button opens a serial data connection to the Adafruit board you
 may have connected to your computer. This will result in a new pane between the
 text editor and Mu's footer. Any serial data emitted from the device will
-appear here. If you need to drop into the MicroPython REPL you should make
+appear here. If you need to drop into the CircuitPython REPL you should make
 sure the pane has keyboard focus (just click it!) and then type CTRL-C, as
 shown below:
 

--- a/en/tutorials/1.1/esp.md
+++ b/en/tutorials/1.1/esp.md
@@ -31,10 +31,10 @@ buttons:
   <br/>
 </div>
 
-The "Serial" button opens a serial data connection to the Adafruit board you
+The "Serial" button opens a serial data connection to the ESP board you
 may have connected to your computer. This will result in a new pane between the
 text editor and Mu's footer. Any serial data emitted from the device will
-appear here. If you need to drop into the CircuitPython REPL you should make
+appear here. If you need to drop into the MicroPython REPL you should make
 sure the pane has keyboard focus (just click it!) and then type CTRL-C, as
 shown below:
 


### PR DESCRIPTION
This fixes Mu issue 1340: https://github.com/mu-editor/mu/issues/1340

This changes the paragraph in the Windows install page about uninstalling an older version of Mu and changes it to:

```
**If you have a version of Mu older than version 1.1 already installed, we recommend that you
uninstall it first.  If you do not uninstall first, you will have two installations of Mu due to 
packaging changes with Mu versions 1.1 and newer.**
```

Sorry about the commit revert, I had an issue with my repo, this PR should be just the one commit.  If I need to change anything, please let me know.