### PR TITLE
Replace OS X references with macOS

### DIFF
--- a/en/howto/1.1/index.html
+++ b/en/howto/1.1/index.html
@@ -13,7 +13,7 @@ a well defined goal.</p>
 
 <ul>
     <li><a href="install_windows">How to install Mu on Windows with the official installer</a>.</li>
-    <li><a href="install_macos">How to install Mu on Mac OSX with the official installer</a>.</li>
+    <li><a href="install_macos">How to install Mu on macOS with the official installer</a>.</li>
     <li><a href="use_portamu">How to use PortaMu to run Mu anywhere</a>.</li>
     <li><a href="install_with_python">How to install Mu with Python packaging on Windows, OSX and Linux</a>.</li>
     <li><a href="install_raspberry_pi">How to install Mu on a Raspberry Pi</a>.</li>

--- a/en/howto/1.1/install_macos.md
+++ b/en/howto/1.1/install_macos.md
@@ -17,14 +17,14 @@ Installing Mu on macOS is super easy.
 + Open your Downloads folder - click "Go", then "Downloads" on the Finder menu. 
 
 <div class="row">
-  <img src="/img/en/howto/macos_go_downloads.png" alt="Mac OS open downloads" class="img-responsive center-block img-rounded"/>
+  <img src="/img/en/howto/macos_go_downloads.png" alt="macOS open downloads" class="img-responsive center-block img-rounded"/>
   <br/>
 </div>
 
 + Double click the Mu installer disk image (a .dmg file).
 
 <div class="row">
-  <img src="/img/en/howto/macos_downloads.png" alt="Mac OS downloads" class="img-responsive center-block img-rounded"/>
+  <img src="/img/en/howto/macos_downloads.png" alt="macOS downloads" class="img-responsive center-block img-rounded"/>
   <br/>
 </div>
 
@@ -37,7 +37,7 @@ may take a couple of minutes).
 + Click, hold and drag the "Mu" icon into the "Applications" folder.
 
 <div class="row">
-  <img src="/img/en/howto/macos1.png" alt="Mac OSX installer step 1" class="img-responsive center-block img-rounded"/>
+  <img src="/img/en/howto/macos1.png" alt="macOS installer step 1" class="img-responsive center-block img-rounded"/>
   <br/>
 </div>
 
@@ -46,7 +46,7 @@ may take a couple of minutes).
 Mu will install into the Applications folder on your Mac.
 
 <div class="row">
-  <img src="/img/en/howto/macos2.png" alt="Mac OSX installer step 2" class="img-responsive center-block img-rounded"/>
+  <img src="/img/en/howto/macos2.png" alt="macOS installer step 2" class="img-responsive center-block img-rounded"/>
 </div>
 
 ## Step 5 - Start Mu
@@ -54,7 +54,7 @@ Mu will install into the Applications folder on your Mac.
 + Open your Applications folder - click "Go", "Applications" on the Finder menu. 
 
 <div class="row">
-  <img src="/img/en/howto/macos_go_applications.png" alt="Mac OS open downloads" class="img-responsive center-block img-rounded"/>
+  <img src="/img/en/howto/macos_go_applications.png" alt="macOS open downloads" class="img-responsive center-block img-rounded"/>
   <br/>
 </div>
 

--- a/en/howto/1.1/install_with_python.md
+++ b/en/howto/1.1/install_with_python.md
@@ -1,19 +1,19 @@
 ---
 layout: default
-title: How to install Mu with Python packaging on Windows, OSX and Linux.
+title: How to install Mu with Python packaging on Windows, macOS and Linux.
 i18n: en
 ---
-# How to install Mu with Python packaging on Windows, OSX and Linux
+# How to install Mu with Python packaging on Windows, macOS and Linux
 
 If you already have [Python3](https://python.org/) installed on your Windows,
-OSX or Linux machine then it is easy to install Mu with Python's
+macOS or Linux machine then it is easy to install Mu with Python's
 built-in package manager, [`pip`](https://pip.pypa.io/en/stable/installing/).
 **Please note: this method does not currently work on Raspberry Pi** (use
 [these instructions instead](/en/howto/1.1/install_raspberry_pi)).
 If you're on Windows and would rather not type commands you should use the
-[Windows installer for Mu](install_windows) instead. If you're using OSX on a
-Mac and want to use the simple drag-and-drop installer instead, you should use
-the [OSX installer for Mu](install_macos).
+[Windows installer for Mu](install_windows) instead. If you're using macOS 
+and want to use the simple drag-and-drop installer instead, you should use
+the [macOS installer for Mu](install_macos).
 
 We recommend you run the following commands in a
 [virtualenv](https://pypi.org/project/virtualenv/)
@@ -61,7 +61,7 @@ Press return and the editor should launch.
         to install Mu.</li>
     </ul>
     <p>If you're still facing problems, perhaps try using another installation
-    method (HINT: if you're on Windows or using OSX on a Mac, use the installer
+    method (HINT: if you're on Windows or using macOS, use the installer
     for the appropriate platform instead).
     As a last resort why not see if anyone can help you in the
     <a href="/en/discuss">discussions</a>.</p>
@@ -82,7 +82,7 @@ using:
 
 * Windows: in the search area of your start menu, type `cmd` and
   press enter.
-* Mac OSX: use the finder to go to the Applications folder and then the
+* macOS: use the Finder to go to the Applications folder and then the
   Utilities folder. Open the "Terminal" app.
 * Linux: look for the "Terminal" app in your desktop's menu.
 


### PR DESCRIPTION
This PR updates any mention of OSX and replaces it with macOS, which is how Apple refers to its operating system now.