### PR TITLE
Fix leftover /1.1/ links to /1.2/

### DIFF
--- a/_includes/nav_en.html
+++ b/_includes/nav_en.html
@@ -15,8 +15,8 @@
               <ul class="nav navbar-nav">
                   <li><a href="/en/download">Download</a></li>
                   <li><a href="/en/about">About</a></li>
-                  <li><a href="/en/tutorials/1.1">Tutorials</a></li>
-                  <li><a href="/en/howto/1.1">How to..?</a></li>
+                  <li><a href="/en/tutorials/1.2/">Tutorials</a></li>
+                  <li><a href="/en/howto/1.2/">How to..?</a></li>
                   <li><a href="/en/discuss">Discuss</a></li>
                   <li><a href="/en/developers">Developers</a></li>
                   <li class="dropdown">

--- a/en/download.md
+++ b/en/download.md
@@ -22,7 +22,7 @@ beta versions of Mu [can be downloaded from here](https://github.com/mu-editor/m
   <div class="media-body">
     <h4 class="media-heading">Windows Installer</h4>
     <p><a id="download-button-windows" href="https://github.com/mu-editor/mu/releases/download/v1.2.0/MuEditor-win64-1.2.0.msi" class="btn btn-primary" role="button">Download</a>
-    <a href="/en/howto/1.1/install_windows" class="btn btn-default" role="button">Instructions</a></p>
+    <a href="/en/howto/1.2/install_windows" class="btn btn-default" role="button">Instructions</a></p>
   </div>
 </div>
 
@@ -35,7 +35,7 @@ beta versions of Mu [can be downloaded from here](https://github.com/mu-editor/m
   <div class="media-body">
     <h4 class="media-heading">Mac OSX Installer</h4>
     <p><a id="download-button-macos" href="https://github.com/mu-editor/mu/releases/download/v1.2.0/MuEditor-OSX-1.2.0.dmg" class="btn btn-primary" role="button">Download</a>
-    <a href="/en/howto/1.1/install_macos" class="btn btn-default" role="button">Instructions</a></p>
+    <a href="/en/howto/1.2/install_macos" class="btn btn-default" role="button">Instructions</a></p>
   </div>
 </div>
 
@@ -48,7 +48,7 @@ beta versions of Mu [can be downloaded from here](https://github.com/mu-editor/m
   <div class="media-body">
     <h4 class="media-heading">Linux AppImage Package (Experimental)</h4>
     <p><a id="download-button-linux" href="https://github.com/mu-editor/mu/releases/download/v1.2.0/MuEditor-Linux-1.2.0-x86_64.AppImage" class="btn btn-primary" role="button">Download</a>
-    <a href="/en/howto/1.1/install_linux" class="btn btn-default" role="button">Instructions</a></p>
+    <a href="/en/howto/1.2/install_linux" class="btn btn-default" role="button">Instructions</a></p>
   </div>
 </div>
 

--- a/en/howto/1.2/copy_files_microbit.md
+++ b/en/howto/1.2/copy_files_microbit.md
@@ -20,7 +20,7 @@ The pane shown below will appear at the bottom of Mu's window. Simply click and
 drag a file between the list of files on the micro:bit and those on your
 computer (as the animation shows). The files on your computer can be found in
 the folder Mu uses as your working directory (see the tutorial called
-[where are my files?](/en/tutorials/1.1/files)).
+[where are my files?](/en/tutorials/1.2/files)).
 
 <div class="row">
   <img src="/img/en/howto/microbit_files.gif" alt="Moving files with a micro:bit" class="img-responsive center-block img-rounded movie"/>

--- a/en/howto/1.2/install_with_python.md
+++ b/en/howto/1.2/install_with_python.md
@@ -9,7 +9,7 @@ If you already have [Python3](https://python.org/) installed on your Windows,
 macOS or Linux machine then it is easy to install Mu with Python's
 built-in package manager, [`pip`](https://pip.pypa.io/en/stable/installing/).
 **Please note: this method does not currently work on Raspberry Pi** (use
-[these instructions instead](/en/howto/1.1/install_raspberry_pi)).
+[these instructions instead](/en/howto/1.2/install_raspberry_pi)).
 If you're on Windows and would rather not type commands you should use the
 [Windows installer for Mu](install_windows) instead. If you're using macOS 
 and want to use the simple drag-and-drop installer instead, you should use

--- a/en/tutorials/1.2/logs.md
+++ b/en/tutorials/1.2/logs.md
@@ -30,7 +30,7 @@ The first tab contains the logs written during the current day:
 </div>
 
 To learn what the log entries mean please read our guide for
-[how to read logs in Mu](/en/howto/1.1/read_logs).
+[how to read logs in Mu](/en/howto/1.2/read_logs).
 
 The second tab allows you to configure various aspects of the environment in
 which Python 3 runs your code (so called "environment variables"):
@@ -41,7 +41,7 @@ which Python 3 runs your code (so called "environment variables"):
 </div>
 
 To learn how to update the Python 3 environment with environment variables,
-read our guide for [how to do this](/en/howto/1.1/python3_envars).
+read our guide for [how to do this](/en/howto/1.2/python3_envars).
 
 Finally, the third tab contains various settings for flashing code onto a
 connected BBC micro:bit:
@@ -52,4 +52,4 @@ connected BBC micro:bit:
 </div>
 
 To learn how to change the way code is flashed onto a connected BBC micro:bit,
-read our guide for [how to do this](/en/howto/1.1/microbit_settings).
+read our guide for [how to do this](/en/howto/1.2/microbit_settings).

--- a/en/tutorials/1.2/problems.md
+++ b/en/tutorials/1.2/problems.md
@@ -11,7 +11,7 @@ As you'll know from writing your own code, all software has bugs!
 Mu is no exception and it's likely you may discover some odd behaviour or Mu
 may report a problem.
 
-If this is the case, we've [created a guide to help you submit a bug report](/en/howto/1.1/bugs).
+If this is the case, we've [created a guide to help you submit a bug report](/en/howto/1.2/bugs).
 We love getting feedback because bug reports help us to improve Mu and make it
 easy for our users to contribute back to the project.
 

--- a/es/download.md
+++ b/es/download.md
@@ -18,7 +18,7 @@ Si eres desarrollador, puedes encontrar el código fuente en
   <div class="media-body">
     <h4 class="media-heading">Instalador Windows</h4>
     <p><a id="download-button-windows" href="https://github.com/mu-editor/mu/releases/download/v1.2.0/MuEditor-win64-1.2.0.msi" class="btn btn-primary" role="button">64-bit</a>
-    <a href="/en/howto/1.1/install_windows" class="btn btn-default" role="button">Instrucciones</a></p>
+    <a href="/en/howto/1.2/install_windows" class="btn btn-default" role="button">Instrucciones</a></p>
   </div>
 </div>
 
@@ -31,7 +31,7 @@ Si eres desarrollador, puedes encontrar el código fuente en
   <div class="media-body">
     <h4 class="media-heading">Instalador Mac OSX</h4>
     <p><a id="download-button-macos" href="https://github.com/mu-editor/mu/releases/download/v1.2.0/MuEditor-OSX-1.2.0.dmg" class="btn btn-primary" role="button">Descargar</a>
-    <a href="/en/howto/1.1/install_macos" class="btn btn-default" role="button">Instrucciones</a></p>
+    <a href="/en/howto/1.2/install_macos" class="btn btn-default" role="button">Instrucciones</a></p>
   </div>
 </div>
 
@@ -44,7 +44,7 @@ Si eres desarrollador, puedes encontrar el código fuente en
   <div class="media-body">
     <h4 class="media-heading">Linux</h4>
     <p><a id="download-button-linux" href="https://github.com/mu-editor/mu/releases/download/v1.2.0/MuEditor-Linux-1.2.0-x86_64.AppImage" class="btn btn-primary" role="button">Descargar</a>
-    <a href="/en/howto/1.1/install_linux" class="btn btn-default" role="button">Instrucciones</a></p>
+    <a href="/en/howto/1.2/install_linux" class="btn btn-default" role="button">Instrucciones</a></p>
   </div>
 </div>
 


### PR DESCRIPTION
@ntoll  some left over 1.1 links from https://github.com/mu-editor/mu-editor.github.io/commit/1461d1f1b2dd43fba0db52837a167aa5c6cbd26a

Most notably the navigation header.