### PR TITLE
Linux Instructions: Wayland env var no longer required

### DIFF
--- a/en/howto/1.2/install_linux.md
+++ b/en/howto/1.2/install_linux.md
@@ -92,18 +92,3 @@ A few, however, require using the terminal to do it:
 
 As of Mu 1.1.1 running Mu requires using the Wayland display server.
 Other than that, double clicking Mu's AppImage works nicely.
-
-
-**Debian 11 (bulleye)**
-
-```
-QT_QPA_PLATFORM=wayland ./Downloads/Mu_Editor-1.1.1-x86_64.AppImage
-```
-
-
-**Ubuntu 22.04 LTS (Jammy Jellyfish)**
-
-```
-QT_QPA_PLATFORM=wayland ./Downloads/Mu_Editor-1.1.1-x86_64.AppImage
-```
-


### PR DESCRIPTION
With the v1.2.0 release, Mu sets up the wayland env var internally and no longer requires the users to follow these steps in Debian/Ubuntu.