### PR TITLE
Fixed Arch Linux package name

### DIFF
--- a/en/howto/1.2/install_linux.md
+++ b/en/howto/1.2/install_linux.md
@@ -73,7 +73,7 @@ Bring up a terminal window and run the following commands:
 **Arch Linux**
 
 ```
-pacman -S libxcript-compat
+pacman -S libxcrypt-compat
 ```
 
 **Ubuntu 22.04 LTS (Jammy Jellyfish)**


### PR DESCRIPTION
Running `pacman -S libxcript-compat` results in `error: target not found: libxcript-compat`. To resolve, Arch Linux package name should be changed from "libxcript-compat" to "libxcrypt-compat", therefore the revised command will read `pacman -S libxcrypt-compat`. Verification of package name can be found here: https://archlinux.org/packages/core/x86_64/libxcrypt-compat/